### PR TITLE
Made detection and parsing less restrictive for Primo translator

### DIFF
--- a/Primo.js
+++ b/Primo.js
@@ -8,7 +8,7 @@
 	"maxVersion":"",
 	"priority":100,
 	"inRepository":true,
-	"lastUpdated":"2010-06-08 07:15:00"
+	"lastUpdated":"2011-05-26 15:20:00"
 }
 
 /*
@@ -65,7 +65,7 @@ function doWeb(doc, url) {
 				titleIterator = doc.evaluate('//h2[contains(@class, "EXLResultTitle")]/a', doc, nsResolver, XPathResult.ANY_TYPE, null);
 			}
 			else {
-				// Primo v3 But make use of details tab. Title does not have to contain a link
+				// Primo v3.1
 				linkIterator = doc.evaluate('//li[contains(@class, "EXLDetailsTab")]/a/@href', doc, nsResolver, XPathResult.ANY_TYPE, null);
 				titleIterator = doc.evaluate('//h2[contains(@class, "EXLResultTitle")]', doc, nsResolver, XPathResult.ANY_TYPE, null);
 			}


### PR DESCRIPTION
Detection and parsing was to restrictive. 
This resulted in Zotero not recognizing all records on a page. 

_Fixes:_
- Expecting classes in a specific order could break the translator if pages get updated.
- Title does not have to contain a link I used the link on the details tab instead. 
